### PR TITLE
Quick cleanup

### DIFF
--- a/mmap.cc
+++ b/mmap.cc
@@ -44,13 +44,21 @@ NAN_METHOD(Map) {
 }
 
 NAN_MODULE_INIT(InitAll) {
-	Set(target, New<String>("PROT_READ").ToLocalChecked(), New<Integer>(static_cast<int8_t>(PROT_READ)));
-	Set(target, New<String>("PROT_WRITE").ToLocalChecked(), New<Integer>(static_cast<int8_t>(PROT_WRITE)));
-	Set(target, New<String>("PROT_EXEC").ToLocalChecked(), New<Integer>(static_cast<int8_t>(PROT_EXEC)));
-	Set(target, New<String>("PROT_NONE").ToLocalChecked(), New<Integer>(static_cast<int8_t>(PROT_NONE)));
-	Set(target, New<String>("MAP_SHARED").ToLocalChecked(), New<Integer>(static_cast<int8_t>(MAP_SHARED)));
-	Set(target, New<String>("MAP_PRIVATE").ToLocalChecked(), New<Integer>(static_cast<int8_t>(MAP_PRIVATE)));
-	Set(target, New<String>("PAGESIZE").ToLocalChecked(), New<Integer>(static_cast<int8_t>(sysconf(_SC_PAGESIZE))));
+	Set(target, New<String>("PROT_READ").ToLocalChecked(), New<Integer>(static_cast<uint32_t>(PROT_READ)));
+	Set(target, New<String>("PROT_WRITE").ToLocalChecked(), New<Integer>(static_cast<uint32_t>(PROT_WRITE)));
+	Set(target, New<String>("PROT_EXEC").ToLocalChecked(), New<Integer>(static_cast<uint32_t>(PROT_EXEC)));
+	Set(target, New<String>("PROT_NONE").ToLocalChecked(), New<Integer>(static_cast<uint32_t>(PROT_NONE)));
+	Set(target, New<String>("MAP_SHARED").ToLocalChecked(), New<Integer>(static_cast<uint32_t>(MAP_SHARED)));
+	Set(target, New<String>("MAP_PRIVATE").ToLocalChecked(), New<Integer>(static_cast<uint32_t>(MAP_PRIVATE)));
+#ifdef MAP_POPULATE
+	Set(target, New<String>("MAP_POPULATE").ToLocalChecked(), New<Integer>(static_cast<uint32_t>(MAP_POPULATE)));
+#endif
+	Set(target, New<String>("MAP_ANONYMOUS").ToLocalChecked(), New<Integer>(static_cast<uint32_t>(MAP_ANONYMOUS)));
+#ifdef MAP_NONBLOCK
+	Set(target, New<String>("MAP_NONBLOCK").ToLocalChecked(), New<Integer>(static_cast<uint32_t>(MAP_NONBLOCK)));
+#endif
+	Set(target, New<String>("MAP_NORESERVE").ToLocalChecked(), New<Integer>(static_cast<uint32_t>(MAP_NORESERVE)));	
+	Set(target, New<String>("PAGESIZE").ToLocalChecked(), New<Integer>(static_cast<uint32_t>(sysconf(_SC_PAGESIZE))));
 	Set(target, New<String>("map").ToLocalChecked(), GetFunction(New<FunctionTemplate>(Map)).ToLocalChecked());
 }
 

--- a/package.json
+++ b/package.json
@@ -11,16 +11,12 @@
         "url" : "https://github.com/f3z0"
     }],
     "dependencies": {
-        "bindings": "^1.2.1",
-         "nan": "~2.5.1"
-      },
+         "nan": "^2.7.0"
+    },
     "description":  "mmap(2) bindings for node.js",
     "homepage":     "https://github.com/f3z0/node-mmap",
     "engines":      { "node": ">=0.12.0" },
     "main":         "./build/Release/mmap",
-    "scripts": {
-        "install": "node-gyp rebuild"
-    },
     "repository": {
         "type":         "git",
         "url":          "https://github.com/f3z0/node-mmap.git"


### PR DESCRIPTION
Some quick code cleanup:

* Use `Nan::ThrowError` and `Nan::ErrnoException` for better compatibility, shorter code.
* Remove unnecessary `HandleScope`.
* Remove a debugging `printf` statement.
* Drop unused `bindings` dependency.
* Remove unncessary `install` script from package.json.
* Update to latest `nan`.

(Thanks for updating Ben's work. Appreciate that there's a simple library for this out there, compared to mmap-io.)